### PR TITLE
Force oversized/text images to fit container

### DIFF
--- a/src/routes/scripts/[slug]/+page.svelte
+++ b/src/routes/scripts/[slug]/+page.svelte
@@ -98,7 +98,7 @@
 	{/if}
 
 	<div class="absolute inset-0 container min-w-full h-96 mx-0 flex flex-col">
-		<img class="z-0 absolute object-cover h-full w-full" src={assets_path} alt={script.assets_alt} />
+		<img class="z-0 absolute object-contain h-full w-full" src={assets_path} alt={script.assets_alt} />
 		<header class="left-0 mt-auto z-10 text-center h-32 text-amber-500 text-shadow">
 			<div
 				class="absolute mx-0 h-32 w-full opacity-100


### PR DESCRIPTION
This will force the images like "Plank Make" to fit in the container rather than being cut off. There are other ways to conditionally force the cut off images to fit, but this is the quickest and easiest solution. Let me know if you want another option.