### PR TITLE
Add coupons

### DIFF
--- a/src/routes/api/stripe/coupons/+server.ts
+++ b/src/routes/api/stripe/coupons/+server.ts
@@ -1,0 +1,66 @@
+import { stripe } from "$lib/server/stripe.server"
+import { error, json } from "@sveltejs/kit"
+
+export const GET = async ({ locals: { user, getProfile } }) => {
+    if (!user) throw error(401, "Unauthorized")
+    
+    const profile = await getProfile()
+    if (!profile?.stripe) throw error(403, "Stripe account required")
+
+    try {
+        // List coupons for the specific connected account
+        const coupons = await stripe.coupons.list({
+            stripeAccount: profile.stripe
+        })
+        return json(coupons.data)
+    } catch (err) {
+        console.error(err)
+        throw error(500, "Failed to fetch coupons")
+    }
+}
+
+export const POST = async ({ request, locals: { user, getProfile } }) => {
+    if (!user) throw error(401, "Unauthorized")
+    
+    const profile = await getProfile()
+    if (!profile?.stripe) throw error(403, "Stripe account required")
+
+    const data = await request.json()
+    
+    try {
+        const coupon = await stripe.coupons.create({
+            percent_off: data.percent_off,
+            duration: data.duration,
+            duration_in_months: data.duration === 'repeating' ? data.duration_in_months : undefined,
+            name: data.name,
+            max_redemptions: data.max_redemptions,
+            metadata: data.metadata
+        }, {
+            stripeAccount: profile.stripe // Create coupon on the connected account
+        })
+        return json(coupon)
+    } catch (err) {
+        console.error(err)
+        throw error(500, "Failed to create coupon")
+    }
+}
+
+export const DELETE = async ({ url, locals: { user, getProfile } }) => {
+    if (!user) throw error(401, "Unauthorized")
+    
+    const profile = await getProfile()
+    if (!profile?.stripe) throw error(403, "Stripe account required")
+
+    const couponId = url.searchParams.get('id')
+    if (!couponId) throw error(400, "Coupon ID is required")
+
+    try {
+        const deleted = await stripe.coupons.del(couponId, {
+            stripeAccount: profile.stripe // Delete from connected account
+        })
+        return json(deleted)
+    } catch (err) {
+        console.error(err)
+        throw error(500, "Failed to delete coupon")
+    }
+} 

--- a/src/routes/dashboard/[slug]/+page.svelte
+++ b/src/routes/dashboard/[slug]/+page.svelte
@@ -17,10 +17,11 @@
 	import { browser } from "$app/environment"
 	import type { RealtimeChannel } from "@supabase/supabase-js"
 	import { Tab, TabGroup } from "@skeletonlabs/skeleton"
-	import { FileCode, Landmark, Package } from "lucide-svelte"
+	import { FileCode, Landmark, Package, Tag } from "lucide-svelte"
 	import type { StripeConnectInstance } from "@stripe/connect-js"
 	import { zodClient } from "sveltekit-superforms/adapters"
 	import TablePlaceholder from "./TablePlaceholder.svelte"
+	import Coupons from "./Coupons.svelte"
 
 	export let data
 
@@ -302,6 +303,10 @@
 				<Tab bind:group={tabSet} name="tab3" value={2}>
 					<div class="flex justify-end"><FileCode /> Scripts</div>
 				</Tab>
+				<Tab bind:group={tabSet} name="tab4" value={3}>
+					<div class="flex justify-end"><Tag /> Coupons</div>
+				</Tab>
+
 				<!-- Tab Panels --->
 				<svelte:fragment slot="panel">
 					{#if tabSet === 0}


### PR DESCRIPTION
I don't have the local environment to test, so I dug through the API and cobbled together some code that Claude says is going to work.

## Overview
This PR adds coupon management functionality for Scripters using Stripe Connect. Scripters can now create, manage, and track discount coupons for their products through their dashboard.

## Key Changes
- Added new `/api/stripe/coupons` endpoints for CRUD operations
- Implemented coupon management UI in Scripter dashboard
- Added proper Stripe Connect integration for per-scripter coupon management
- Coupons work with existing checkout flow (already had `allow_promotion_codes: true`)
